### PR TITLE
simplify recipe for cb3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
 
-# FIXME: This is a hack to make sure the environment is activated.
-# The reason this is required is due to the conda-build issue
-# mentioned below.
-#
-# https://github.com/conda/conda-build/issues/910
-#
-#source activate "${CONDA_DEFAULT_ENV}"
-
 if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-  export CXX="${CXX} -stdlib=libc++"
-  export LDFLAGS="${LDFLAGS} -mmacosx-version-min=10.9"
-  export MACOSX_DEPLOYMENT_TARGET=10.9
 elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
 
 # Pass explicit paths to the prefix for each dependency.
 ./configure --prefix="${PREFIX}" \
+            --host=$HOST \
+            --build=$BUILD \
             --with-zlib-include-dir="${PREFIX}/include" \
             --with-zlib-lib-dir="${PREFIX}/lib" \
             --with-jpeg-include-dir="${PREFIX}/include" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,32 +13,32 @@ source:
     - def_snprintf.patch  # [win]
 
 build:
-  number: 7
+  number: 8
   features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and py35]
+    - vc{{ vc }}  # [win]
 
 requirements:
   host:
-    - zlib 1.2.*
-    - jpeg 9*
-    - xz 5.2.*  # [not win]
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py35]
+    - zlib
+    - jpeg
+    - xz    # [not win]
   build:
     - cmake  # [win]
-    - python  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  run:
-    - zlib 1.2.*
-    - jpeg 9*
-    - xz 5.2.*  # [not win]
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py35]
+  # run:
+    # zlib removed here because zlib package has run_exports for itself
+    #    https://github.com/AnacondaRecipes/zlib-feedstock/pull/2
+    # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
+    # - zlib
+    # jpeg removed here because package has run_exports for itself
+    #    https://github.com/AnacondaRecipes/jpeg-feedstock/pull/1
+    # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
+    # - jpeg 9*
+    # xz removed here because xz package has run_exports for itself
+    #    https://github.com/AnacondaRecipes/xz-feedstock/pull/2
+    # this req isn't actually necessary, as run_exports will add it.  Left here for reference.
+    # - xz 5.2.*  # [not win]
 
 test:
   commands:
@@ -66,3 +66,4 @@ extra:
     - jakirkham
     - ocefpaf
     - stuarteberg
+    - msarahan


### PR DESCRIPTION
not working yet.  Error linking:

```
ld: symbol(s) not found for architecture x86_64
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libtiffxx.la] Error 1
make[1]: *** [all] Error 2
make: *** [all-recursive] Error 1
```