### PR TITLE
libtiff 4.1.0 rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,4 +18,3 @@ copy "%LIBRARY_PREFIX%"\bin\tiff.dll "%LIBRARY_PREFIX%"\bin\libtiff.dll
 copy "%LIBRARY_PREFIX%"\lib\tiff.lib "%LIBRARY_PREFIX%"\lib\libtiff.lib
 
 copy "%LIBRARY_PREFIX%"\bin\tiffxx.dll "%LIBRARY_PREFIX%"\bin\libtiffxx.dll
-copy "%LIBRARY_PREFIX%"\lib\tiffxx.lib "%LIBRARY_PREFIX%"\lib\libtiffxx.lib

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,4 +15,7 @@ cmake --build . --target install --config Release
 if errorlevel 1 exit /b 1
 
 copy "%LIBRARY_PREFIX%"\bin\tiff.dll "%LIBRARY_PREFIX%"\bin\libtiff.dll
+copy "%LIBRARY_PREFIX%"\lib\tiff.lib "%LIBRARY_PREFIX%"\lib\libtiff.lib
+
 copy "%LIBRARY_PREFIX%"\bin\tiffxx.dll "%LIBRARY_PREFIX%"\bin\libtiffxx.dll
+copy "%LIBRARY_PREFIX%"\lib\tiffxx.lib "%LIBRARY_PREFIX%"\lib\libtiffxx.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/fix_TIFFReadRawStrip_man_page_typo.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   # Does a very good job of maintaining compatibility.
   #    https://abi-laboratory.pro/tracker/timeline/libtiff/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 1
-  skip: True  # [win and vc<14]
+  # This version was never built for osx-arm64.
+  skip: True  # [(win and vc<14) or (osx and arm64)]
   # Does a very good job of maintaining compatibility.
   #    https://abi-laboratory.pro/tracker/timeline/libtiff/
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,14 +55,16 @@ test:
     - if not exist %PREFIX%\\Library\\bin\\libtiffxx.dll exit 1  # [win]
 
 about:
-  home: http://www.libtiff.org/
-  license: HPND
+  home: https://libtiff.gitlab.io/libtiff/
+  license: libtiff
   license_file: COPYRIGHT
+  license_family: OTHER
   summary: 'Support for the Tag Image File Format (TIFF).'
   description: |
     This software provides support for the Tag Image File Format (TIFF), a
     widely used format for storing image data.
-  doc_url: http://www.libtiff.org/document.html
+  dev_url: https://gitlab.com/libtiff/libtiff
+  doc_url: http://www.simplesystems.org/libtiff/
 
 extra:
    recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - cmake   # [win]
     - ninja   # [win]
     - make    # [not win]
+    - patch   # [not win]
+    - m2-patch  # [win]
   host:
     - zlib
     - jpeg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,10 @@ build:
   #    https://abi-laboratory.pro/tracker/timeline/libtiff/
   run_exports:
     - {{ pin_subpackage('libtiff', max_pin='x') }}
+  ignore_run_exports:
+    # No signs of jpeg when running dumpbin /dependents on the tiff DLLs, but
+    # it's used during build, so it is probably being statically linked.
+    - jpeg  # [win]
   missing_dso_whitelist:
     # Only used by libtiff,bin/tiffgt (a viewer), which is ok.
     - /opt/X11/lib/libGL.1.dylib
@@ -34,11 +38,6 @@ requirements:
     - patch   # [not win]
     - m2-patch  # [win]
   host:
-    - zlib
-    - jpeg
-    - xz
-    - zstd
-  run:
     - zlib
     - jpeg
     - xz


### PR DESCRIPTION
We need to rebuild libtiff against the latest available zstd package.