### PR TITLE
libtiff 4.4.0 CVE patches

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,9 @@ source:
   - url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
     sha256: 917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed
     patches:
-      - patches/CVE-2022-2056.patch
+      - patches/0001_CVE-2022-2056.patch
+      - patches/0002_CVE-2022-2953.patch
+      - patches/0003_CVE-2022-34526.patch
     folder: .
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   - url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
     sha256: 917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed
+    patches:
+      - patches/CVE-2022-2056.patch
     folder: .
 
 build:
@@ -36,6 +38,9 @@ requirements:
     - libtool       # [unix]
     - make          # [not win]
     - ninja         # [win]
+    - m2-patch      # [win]
+    - patch         # [not win]
+
   host:
     - jpeg
     - libwebp-base  # [linux or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,8 @@ about:
   home: http://www.simplesystems.org/libtiff/
   license: HPND
   license_file: COPYRIGHT
+  license_family: Other
+  license_url: http://www.simplesystems.org/libtiff/project/license.html
   summary: Support for the Tag Image File Format (TIFF).
   description: |
     This software provides support for the Tag Image File Format (TIFF), a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     folder: .
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # Does a very good job of maintaining compatibility.

--- a/recipe/patches/0001_CVE-2022-2056.patch
+++ b/recipe/patches/0001_CVE-2022-2056.patch
@@ -1,5 +1,4 @@
 This patch addresses CVE-2022-2056, CVE-2022-2057, and CVE-2022-2058.
-It includes the following commits:
 https://gitlab.com/libtiff/libtiff/-/commit/f3a5e0107ffb97b2f002ce0f8df173a515b611b6
 https://gitlab.com/libtiff/libtiff/-/commit/c5e6b2fff0c45ccf5d6e8dc7fdcdadcb24c1328a
 

--- a/recipe/patches/0002_CVE-2022-2953.patch
+++ b/recipe/patches/0002_CVE-2022-2953.patch
@@ -1,0 +1,82 @@
+This patch addresses CVE-2022-2953.
+https://gitlab.com/libtiff/libtiff/-/commit/48d6ece8389b01129e7d357f0985c8f938ce3da3
+
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 90286a5eb20288e488de44fdc7dd51ee3b7dfa32..8fd856dcda05afa2c61f580138903413bb130f77 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -108,12 +108,12 @@
+  *                lower level, scanline level routines. Debug reports a limited set
+  *                of messages to monitor progress without enabling dump logs.
+  * 
+- * Note:    The (-X|-Y), -Z and -z options are mutually exclusive.
++ * Note:    The (-X|-Y), -Z, -z and -S options are mutually exclusive.
+  *          In no case should the options be applied to a given selection successively.
+  */
+ 
+-static   char tiffcrop_version_id[] = "2.5";
+-static   char tiffcrop_rev_date[] = "02-09-2022";
++static   char tiffcrop_version_id[] = "2.5.1";
++static   char tiffcrop_rev_date[] = "15-08-2022";
+ 
+ #include "tif_config.h"
+ #include "libport.h"
+@@ -173,12 +173,12 @@ static   char tiffcrop_rev_date[] = "02-09-2022";
+ #define ROTATECW_270 32
+ #define ROTATE_ANY (ROTATECW_90 | ROTATECW_180 | ROTATECW_270)
+ 
+-#define CROP_NONE     0
+-#define CROP_MARGINS  1
+-#define CROP_WIDTH    2
+-#define CROP_LENGTH   4
+-#define CROP_ZONES    8
+-#define CROP_REGIONS 16
++#define CROP_NONE     0     /* "-S" -> Page_MODE_ROWSCOLS and page->rows/->cols != 0 */
++#define CROP_MARGINS  1     /* "-m" */
++#define CROP_WIDTH    2     /* "-X" */
++#define CROP_LENGTH   4     /* "-Y" */
++#define CROP_ZONES    8     /* "-Z" */
++#define CROP_REGIONS 16     /* "-z" */
+ #define CROP_ROTATE  32
+ #define CROP_MIRROR  64
+ #define CROP_INVERT 128
+@@ -316,7 +316,7 @@ struct crop_mask {
+ #define PAGE_MODE_RESOLUTION   1
+ #define PAGE_MODE_PAPERSIZE    2
+ #define PAGE_MODE_MARGINS      4
+-#define PAGE_MODE_ROWSCOLS     8
++#define PAGE_MODE_ROWSCOLS     8    /* for -S option */
+ 
+ #define INVERT_DATA_ONLY      10
+ #define INVERT_DATA_AND_TAG   11
+@@ -781,7 +781,7 @@ static const char usage_info[] =
+ "             The four debug/dump options are independent, though it makes little sense to\n"
+ "             specify a dump file without specifying a detail level.\n"
+ "\n"
+-"Note:        The (-X|-Y), -Z and -z options are mutually exclusive.\n"
++"Note:        The (-X|-Y), -Z, -z and -S options are mutually exclusive.\n"
+ "             In no case should the options be applied to a given selection successively.\n"
+ "\n"
+ ;
+@@ -2131,13 +2131,14 @@ void  process_command_opts (int argc, char *argv[], char *mp, char *mode, uint32
+ 		/*NOTREACHED*/
+       }
+     }
+-    /*-- Check for not allowed combinations (e.g. -X, -Y and -Z and -z are mutually exclusive) --*/
+-    char XY, Z, R;
+-    XY = ((crop_data->crop_mode & CROP_WIDTH) || (crop_data->crop_mode & CROP_LENGTH));
+-    Z = (crop_data->crop_mode & CROP_ZONES);
+-    R = (crop_data->crop_mode & CROP_REGIONS);
+-    if ((XY && Z) || (XY && R) || (Z && R)) {
+-        TIFFError("tiffcrop input error", "The crop options(-X|-Y), -Z and -z are mutually exclusive.->Exit");
++    /*-- Check for not allowed combinations (e.g. -X, -Y and -Z, -z and -S are mutually exclusive) --*/
++    char XY, Z, R, S;
++    XY = ((crop_data->crop_mode & CROP_WIDTH) || (crop_data->crop_mode & CROP_LENGTH)) ? 1 : 0;
++    Z = (crop_data->crop_mode & CROP_ZONES) ? 1 : 0;
++    R = (crop_data->crop_mode & CROP_REGIONS) ? 1 : 0;
++    S = (page->mode & PAGE_MODE_ROWSCOLS) ? 1 : 0;
++    if (XY + Z + R + S > 1) {
++        TIFFError("tiffcrop input error", "The crop options(-X|-Y), -Z, -z and -S are mutually exclusive.->Exit");
+         exit(EXIT_FAILURE);
+     }
+   }  /* end process_command_opts */

--- a/recipe/patches/0003_CVE-2022-34526.patch
+++ b/recipe/patches/0003_CVE-2022-34526.patch
@@ -1,0 +1,20 @@
+This patch addresses CVE-2022-34526.
+https://gitlab.com/libtiff/libtiff/-/commit/275735d0354e39c0ac1dc3c0db2120d6f31d1990
+
+This CVE only applies if libtiff was built without zstd support.
+Currently we do build with this, but this is included to err on the side of caution.
+
+diff --git a/libtiff/tif_dirinfo.c b/libtiff/tif_dirinfo.c
+index c30f569b8924ba5e43a73fdd2873b06bb78bd715..3371cb5cde70b678f535343ab3fd5c8b81348d95 100644
+--- a/libtiff/tif_dirinfo.c
++++ b/libtiff/tif_dirinfo.c
+@@ -1191,6 +1191,9 @@ _TIFFCheckFieldIsValidForCodec(TIFF *tif, ttag_t tag)
+ 	    default:
+ 		return 1;
+ 	}
++	if( !TIFFIsCODECConfigured(tif->tif_dir.td_compression) ) {
++		return 0;
++	}
+ 	/* Check if codec specific tags are allowed for the current
+ 	 * compression scheme (codec) */
+ 	switch (tif->tif_dir.td_compression) {

--- a/recipe/patches/CVE-2022-2056.patch
+++ b/recipe/patches/CVE-2022-2056.patch
@@ -1,0 +1,188 @@
+This patch addresses CVE-2022-2056, CVE-2022-2057, and CVE-2022-2058.
+It includes the following commits:
+https://gitlab.com/libtiff/libtiff/-/commit/f3a5e0107ffb97b2f002ce0f8df173a515b611b6
+https://gitlab.com/libtiff/libtiff/-/commit/c5e6b2fff0c45ccf5d6e8dc7fdcdadcb24c1328a
+
+diff --git a/libtiff/tif_aux.c b/libtiff/tif_aux.c
+index 140f26c7df6a74a77c353ab5721705bb5269f723..5b88c8d0d25ccf5d898f5292cc5e5f2ef8de5b78 100644
+--- a/libtiff/tif_aux.c
++++ b/libtiff/tif_aux.c
+@@ -402,6 +402,15 @@ float _TIFFClampDoubleToFloat( double val )
+     return (float)val;
+ }
+ 
++uint32_t _TIFFClampDoubleToUInt32(double val)
++{
++    if( val < 0 )
++        return 0;
++    if( val > 0xFFFFFFFFU || val != val )
++        return 0xFFFFFFFFU;
++    return (uint32_t)val;
++}
++
+ int _TIFFSeekOK(TIFF* tif, toff_t off)
+ {
+     /* Huge offsets, especially -1 / UINT64_MAX, can cause issues */
+diff --git a/libtiff/tiffiop.h b/libtiff/tiffiop.h
+index e3af461d034813328880a585ac4af100fdee3732..4e8bdac2276d49ac92837b5e7a485e5eb92e4614 100644
+--- a/libtiff/tiffiop.h
++++ b/libtiff/tiffiop.h
+@@ -365,6 +365,7 @@ extern double _TIFFUInt64ToDouble(uint64_t);
+ extern float _TIFFUInt64ToFloat(uint64_t);
+ 
+ extern float _TIFFClampDoubleToFloat(double);
++extern uint32_t _TIFFClampDoubleToUInt32(double);
+ 
+ extern tmsize_t
+ _TIFFReadEncodedStripAndAllocBuffer(TIFF* tif, uint32_t strip,
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 1f827b2b9ab97b253e9a23e7db7da2415c5abb99..90286a5eb20288e488de44fdc7dd51ee3b7dfa32 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5268,17 +5268,17 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+       {
+       if ((crop->res_unit == RESUNIT_INCH) || (crop->res_unit == RESUNIT_CENTIMETER))
+         {
+-	x1 = (uint32_t) (crop->corners[i].X1 * scale * xres);
+-	x2 = (uint32_t) (crop->corners[i].X2 * scale * xres);
+-	y1 = (uint32_t) (crop->corners[i].Y1 * scale * yres);
+-	y2 = (uint32_t) (crop->corners[i].Y2 * scale * yres);
++	x1 = _TIFFClampDoubleToUInt32(crop->corners[i].X1 * scale * xres);
++	x2 = _TIFFClampDoubleToUInt32(crop->corners[i].X2 * scale * xres);
++	y1 = _TIFFClampDoubleToUInt32(crop->corners[i].Y1 * scale * yres);
++	y2 = _TIFFClampDoubleToUInt32(crop->corners[i].Y2 * scale * yres);
+         }
+       else
+         {
+-	x1 = (uint32_t) (crop->corners[i].X1);
+-	x2 = (uint32_t) (crop->corners[i].X2);
+-	y1 = (uint32_t) (crop->corners[i].Y1);
+-	y2 = (uint32_t) (crop->corners[i].Y2);
++	x1 = _TIFFClampDoubleToUInt32(crop->corners[i].X1);
++	x2 = _TIFFClampDoubleToUInt32(crop->corners[i].X2);
++	y1 = _TIFFClampDoubleToUInt32(crop->corners[i].Y1);
++	y2 = _TIFFClampDoubleToUInt32(crop->corners[i].Y2);
+ 	}
+       /* a) Region needs to be within image sizes 0.. width-1; 0..length-1 
+        * b) Corners are expected to be submitted as top-left to bottom-right.
+@@ -5357,17 +5357,17 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+     {
+     if (crop->res_unit != RESUNIT_INCH && crop->res_unit != RESUNIT_CENTIMETER)
+       { /* User has specified pixels as reference unit */
+-      tmargin = (uint32_t)(crop->margins[0]);
+-      lmargin = (uint32_t)(crop->margins[1]);
+-      bmargin = (uint32_t)(crop->margins[2]);
+-      rmargin = (uint32_t)(crop->margins[3]);
++      tmargin = _TIFFClampDoubleToUInt32(crop->margins[0]);
++      lmargin = _TIFFClampDoubleToUInt32(crop->margins[1]);
++      bmargin = _TIFFClampDoubleToUInt32(crop->margins[2]);
++      rmargin = _TIFFClampDoubleToUInt32(crop->margins[3]);
+       }
+     else
+       { /* inches or centimeters specified */
+-      tmargin = (uint32_t)(crop->margins[0] * scale * yres);
+-      lmargin = (uint32_t)(crop->margins[1] * scale * xres);
+-      bmargin = (uint32_t)(crop->margins[2] * scale * yres);
+-      rmargin = (uint32_t)(crop->margins[3] * scale * xres);
++      tmargin = _TIFFClampDoubleToUInt32(crop->margins[0] * scale * yres);
++      lmargin = _TIFFClampDoubleToUInt32(crop->margins[1] * scale * xres);
++      bmargin = _TIFFClampDoubleToUInt32(crop->margins[2] * scale * yres);
++      rmargin = _TIFFClampDoubleToUInt32(crop->margins[3] * scale * xres);
+       }
+ 
+     if ((lmargin + rmargin) > image->width)
+@@ -5397,24 +5397,24 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+   if (crop->res_unit != RESUNIT_INCH && crop->res_unit != RESUNIT_CENTIMETER)
+     {
+     if (crop->crop_mode & CROP_WIDTH)
+-      width = (uint32_t)crop->width;
++      width = _TIFFClampDoubleToUInt32(crop->width);
+     else
+       width = image->width - lmargin - rmargin;
+ 
+     if (crop->crop_mode & CROP_LENGTH)
+-      length  = (uint32_t)crop->length;
++      length  = _TIFFClampDoubleToUInt32(crop->length);
+     else
+       length = image->length - tmargin - bmargin;
+     }
+   else
+     {
+     if (crop->crop_mode & CROP_WIDTH)
+-      width = (uint32_t)(crop->width * scale * image->xres);
++      width = _TIFFClampDoubleToUInt32(crop->width * scale * image->xres);
+     else
+       width = image->width - lmargin - rmargin;
+ 
+     if (crop->crop_mode & CROP_LENGTH)
+-      length  = (uint32_t)(crop->length * scale * image->yres);
++      length  = _TIFFClampDoubleToUInt32(crop->length * scale * image->yres);
+     else
+       length = image->length - tmargin - bmargin;
+     }
+@@ -5868,13 +5868,13 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+     {
+     if (page->res_unit == RESUNIT_INCH || page->res_unit == RESUNIT_CENTIMETER)
+       { /* inches or centimeters specified */
+-      hmargin = (uint32_t)(page->hmargin * scale * page->hres * ((image->bps + 7) / 8));
+-      vmargin = (uint32_t)(page->vmargin * scale * page->vres * ((image->bps + 7) / 8));
++      hmargin = _TIFFClampDoubleToUInt32(page->hmargin * scale * page->hres * ((image->bps + 7) / 8));
++      vmargin = _TIFFClampDoubleToUInt32(page->vmargin * scale * page->vres * ((image->bps + 7) / 8));
+       }
+     else
+       { /* Otherwise user has specified pixels as reference unit */
+-      hmargin = (uint32_t)(page->hmargin * scale * ((image->bps + 7) / 8));
+-      vmargin = (uint32_t)(page->vmargin * scale * ((image->bps + 7) / 8));
++      hmargin = _TIFFClampDoubleToUInt32(page->hmargin * scale * ((image->bps + 7) / 8));
++      vmargin = _TIFFClampDoubleToUInt32(page->vmargin * scale * ((image->bps + 7) / 8));
+       }
+ 
+     if ((hmargin * 2.0) > (pwidth * page->hres))
+@@ -5912,13 +5912,13 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+     {
+     if (page->mode & PAGE_MODE_PAPERSIZE )
+       {
+-      owidth  = (uint32_t)((pwidth * page->hres) - (hmargin * 2));
+-      olength = (uint32_t)((plength * page->vres) - (vmargin * 2));
++      owidth  = _TIFFClampDoubleToUInt32((pwidth * page->hres) - (hmargin * 2));
++      olength = _TIFFClampDoubleToUInt32((plength * page->vres) - (vmargin * 2));
+       }
+     else
+       {
+-      owidth = (uint32_t)(iwidth - (hmargin * 2 * page->hres));
+-      olength = (uint32_t)(ilength - (vmargin * 2 * page->vres));
++      owidth = _TIFFClampDoubleToUInt32(iwidth - (hmargin * 2 * page->hres));
++      olength = _TIFFClampDoubleToUInt32(ilength - (vmargin * 2 * page->vres));
+       }
+     }
+ 
+@@ -5927,6 +5927,12 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+   if (olength > ilength)
+     olength = ilength;
+ 
++  if (owidth == 0 || olength == 0)
++  {
++    TIFFError("computeOutputPixelOffsets", "Integer overflow when calculating the number of pages");
++    exit(EXIT_FAILURE);
++  }
++
+   /* Compute the number of pages required for Portrait or Landscape */
+   switch (page->orient)
+     {
+diff --git a/libtiff/libtiff.def b/libtiff/libtiff.def
+index 3d2ab7524b0b8ff8b31cf32bb5babdb5cf60b35b..421dfeaba08a2721033695a565e507267658381a 100644
+--- a/libtiff/libtiff.def
++++ b/libtiff/libtiff.def
+@@ -170,6 +170,7 @@ EXPORTS	TIFFAccessTagMethods
+ 	TIFFYCbCrtoRGB
+ 	_TIFFCheckMalloc
+ 	_TIFFCheckRealloc
++	_TIFFClampDoubleToUInt32
+ 	_TIFFRewriteField
+ 	_TIFFfree
+ 	_TIFFmalloc
+@@ -181,4 +182,3 @@ EXPORTS	TIFFAccessTagMethods
+ 	_TIFFMultiply64
+ 	_TIFFGetExifFields
+ 	_TIFFGetGpsFields
+-


### PR DESCRIPTION
## Changes

- Added `license_family` and `license_url`
- Addressed the following CVEs:
  - CVE-2022-2056
  - CVE-2022-2057
  - CVE-2022-2058
  - CVE-2022-34526
  - CVE-2022-2953

## Links

- Home: http://www.simplesystems.org/libtiff/
- GitLab: https://gitlab.com/libtiff/libtiff
- CVEs and `libtiff` GitLab for patch sources:
  - CVE-2022-2056, CVE-2022-2057, CVE-2022-2058: 
    - https://gitlab.com/libtiff/libtiff/-/commit/f3a5e0107ffb97b2f002ce0f8df173a515b611b6
  - CVE-2022-2953:
    - https://gitlab.com/libtiff/libtiff/-/commit/48d6ece8389b01129e7d357f0985c8f938ce3da3
  - CVE-2022-34526:
    - https://gitlab.com/libtiff/libtiff/-/commit/275735d0354e39c0ac1dc3c0db2120d6f31d1990

## Notes
- The official `libtiff` website, http://www.simplesystems.org/libtiff/, does not support `https`. Please ignore linter messages regarding this.
- CVE-2022-34526 only applies if `libtiff` was built without `zstd` support. We do build with this, but the patch was still included for the sake of completeness in case this changes at some later date.
- A patched `libtiff` was tested with the PoCs in a virtual `linux-64` environment and was shown to address the issues reported in the CVEs.