### PR TITLE
libtiff 4.4.0 patch for CVE-2022-3970

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     folder: .
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     # Does a very good job of maintaining compatibility.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
       - patches/0004_CVE-2022-3597.patch
       - patches/0005_CVE-2022-3570.patch
       - patches/0006_CVE-2022-3599.patch
+      - patches/0007_CVE-2022-3970.patch
     folder: .
 
 build:

--- a/recipe/patches/0006_CVE-2022-3599.patch
+++ b/recipe/patches/0006_CVE-2022-3599.patch
@@ -50,7 +50,7 @@ index 9b153b631d37f3cf0fd3b7ae38cea8448523e4d7..1d8d306c8ccf92781e36aa94ebdd042e
  	return (0);
  }
  
-@@ -478,13 +476,61 @@ _TIFFVSetField(TIFF* tif, uint32_t tag, va_list ap)
+@@ -475,13 +473,61 @@ _TIFFVSetField(TIFF* tif, uint32_t tag, va_list ap)
  		_TIFFsetFloatArray(&td->td_refblackwhite, va_arg(ap, float*), 6);
  		break;
  	case TIFFTAG_INKNAMES:
@@ -119,7 +119,7 @@ index 9b153b631d37f3cf0fd3b7ae38cea8448523e4d7..1d8d306c8ccf92781e36aa94ebdd042e
  		}
  		break;
  	case TIFFTAG_PERSAMPLE:
-@@ -986,34 +1032,6 @@ _TIFFVGetField(TIFF* tif, uint32_t tag, va_list ap)
+@@ -915,34 +961,6 @@ _TIFFVGetField(TIFF* tif, uint32_t tag, va_list ap)
  	if (fip->field_bit == FIELD_CUSTOM) {
  		standard_tag = 0;
  	}
@@ -154,7 +154,7 @@ index 9b153b631d37f3cf0fd3b7ae38cea8448523e4d7..1d8d306c8ccf92781e36aa94ebdd042e
  
  	switch (standard_tag) {
  		case TIFFTAG_SUBFILETYPE:
-@@ -1195,6 +1213,9 @@ _TIFFVGetField(TIFF* tif, uint32_t tag, va_list ap)
+@@ -1124,6 +1142,9 @@ _TIFFVGetField(TIFF* tif, uint32_t tag, va_list ap)
  		case TIFFTAG_INKNAMES:
  			*va_arg(ap, const char**) = td->td_inknames;
  			break;
@@ -165,7 +165,7 @@ index 9b153b631d37f3cf0fd3b7ae38cea8448523e4d7..1d8d306c8ccf92781e36aa94ebdd042e
  			{
  				int i;
 diff --git a/libtiff/tif_dir.h b/libtiff/tif_dir.h
-index 2279d8154ddc6f8e5a6428c3097a9d7e43fb10ad..deaa459467b10bb78db177878f5f023dc3afe771 100644
+index 09065648..0c251c9e 100644
 --- a/libtiff/tif_dir.h
 +++ b/libtiff/tif_dir.h
 @@ -117,6 +117,7 @@ typedef struct {
@@ -185,7 +185,7 @@ index 2279d8154ddc6f8e5a6428c3097a9d7e43fb10ad..deaa459467b10bb78db177878f5f023d
  /* end of support for well-known tags; codec-private tags follow */
  #define FIELD_CODEC                    66  /* base of codec-private tags */
 diff --git a/libtiff/tif_dirinfo.c b/libtiff/tif_dirinfo.c
-index 3371cb5cde70b678f535343ab3fd5c8b81348d95..3b4bcd33ad91806f6b8e6eb15a0694040b511546 100644
+index 3371cb5c..3b4bcd33 100644
 --- a/libtiff/tif_dirinfo.c
 +++ b/libtiff/tif_dirinfo.c
 @@ -114,7 +114,7 @@ tiffFields[] = {
@@ -198,10 +198,10 @@ index 3371cb5cde70b678f535343ab3fd5c8b81348d95..3b4bcd33ad91806f6b8e6eb15a069404
  	{ TIFFTAG_TARGETPRINTER, -1, -1, TIFF_ASCII, 0, TIFF_SETGET_ASCII, TIFF_SETGET_UNDEFINED, FIELD_CUSTOM, 1, 0, "TargetPrinter", NULL },
  	{ TIFFTAG_EXTRASAMPLES, -1, -1, TIFF_SHORT, 0, TIFF_SETGET_C16_UINT16, TIFF_SETGET_UNDEFINED, FIELD_EXTRASAMPLES, 0, 1, "ExtraSamples", NULL },
 diff --git a/libtiff/tif_dirwrite.c b/libtiff/tif_dirwrite.c
-index 6c86fdca61e81ca3520070a6897b8e5a6f4c789a..062e46101cb61b932bc0bebaed93f2157ed791d5 100644
+index 2fef6d82..1a00edbf 100644
 --- a/libtiff/tif_dirwrite.c
 +++ b/libtiff/tif_dirwrite.c
-@@ -626,6 +626,11 @@ TIFFWriteDirectorySec(TIFF* tif, int isimage, int imagedone, uint64_t* pdiroff)
+@@ -708,6 +708,11 @@ TIFFWriteDirectorySec(TIFF* tif, int isimage, int imagedone, uint64_t* pdiroff)
  				if (!TIFFWriteDirectoryTagAscii(tif,&ndir,dir,TIFFTAG_INKNAMES,tif->tif_dir.td_inknameslen,tif->tif_dir.td_inknames))
  					goto bad;
  			}
@@ -214,10 +214,10 @@ index 6c86fdca61e81ca3520070a6897b8e5a6f4c789a..062e46101cb61b932bc0bebaed93f215
  			{
  				if (!TIFFWriteDirectoryTagSubifd(tif,&ndir,dir))
 diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
-index 16ce57802e91cad04580bb753a69424b08da99c8..a91b9e7b4c03eba1ce9ade4222de7a5c95033791 100644
+index 80a9d90f..1ed90e28 100644
 --- a/libtiff/tif_print.c
 +++ b/libtiff/tif_print.c
-@@ -397,6 +397,10 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
+@@ -401,6 +401,10 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
  		}
                  fputs("\n", fd);
  	}

--- a/recipe/patches/0007_CVE-2022-3970.patch
+++ b/recipe/patches/0007_CVE-2022-3970.patch
@@ -1,0 +1,27 @@
+This patch addresses CVE-2022-3970.
+https://gitlab.com/libtiff/libtiff/-/commit/227500897dfb07fb7d27f7aa570050e62617e3be
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index a4d0c1d698f89cd403265f6342b6281b9cdaaf73..60b94d8ed6a97e6a5019c58c1650b7673aee3d82 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -3058,15 +3058,15 @@ TIFFReadRGBATileExt(TIFF* tif, uint32_t col, uint32_t row, uint32_t * raster, in
+         return( ok );
+ 
+     for( i_row = 0; i_row < read_ysize; i_row++ ) {
+-        memmove( raster + (tile_ysize - i_row - 1) * tile_xsize,
+-                 raster + (read_ysize - i_row - 1) * read_xsize,
++        memmove( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
++                 raster + (size_t)(read_ysize - i_row - 1) * read_xsize,
+                  read_xsize * sizeof(uint32_t) );
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize+read_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize+read_xsize,
+                      0, sizeof(uint32_t) * (tile_xsize - read_xsize) );
+     }
+ 
+     for( i_row = read_ysize; i_row < tile_ysize; i_row++ ) {
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
+                      0, sizeof(uint32_t) * tile_xsize );
+     }
+ 


### PR DESCRIPTION
## Changes
- Patch to address CVE-2022-3970
 
## Links
- Home: http://www.simplesystems.org/libtiff/
- GitLab: https://gitlab.com/libtiff/libtiff
- CVEs and `libtiff` GitLab for patch sources:
  - CVE-2022-3970
    https://gitlab.com/libtiff/libtiff/-/commit/227500897dfb07fb7d27f7aa570050e62617e3be

## Notes
- This patch adds a typecast to ensure that a multiplication performed on two 32bit integers will not overflow.