### PR TITLE
update 4.5.0 for fixing pinnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * text=auto
 
-*.patch binary
-*.diff binary
+*.patch text eol=lf
+*.diff text eol=lf
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - jpeg 9e
     - libwebp-base  # [linux or osx]
     - xz 5.2.*
-    - zlib 1.2.11
+    - zlib 1.2.13  # should be actually 1.2.11, but pinning hell
     - zstd 1.5.2
     - lerc 3.0
     - libdeflate 1.7  # [s390x or aarch64]
@@ -45,7 +45,7 @@ requirements:
     - jpeg >=9e,<10a
     - libwebp-base  # [linux or osx]
     - xz >=5.2.4,<6.0a0
-    - zlib >=1.2.11,<1.3.0a0
+    - zlib >=1.2.13,<1.3.0a0
     - zstd >=1.5.2,<1.6.0a0
     - lerc >=3.0,<4.0a0
     - libdeflate >=1.8,<1.9.0a0  # [not (s390x or aarch64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     - zlib 1.2.11
     - zstd 1.5.2
     - lerc 3.0
-    - libdeflate 1.7  # [not arm64]
-    - libdeflate 1.8  # [arm64]
+    - libdeflate 1.7  # [s390x or aarch64]
+    - libdeflate 1.8  # [not (s390x or aarch64)]
   run:
     - jpeg >=9e,<10a
     - libwebp-base  # [linux or osx]
@@ -48,7 +48,8 @@ requirements:
     - zlib >=1.2.11,<1.3.0a0
     - zstd >=1.5.2,<1.6.0a0
     - lerc >=3.0,<4.0a0
-    - libdeflate >=1.8,<1.9.0a0
+    - libdeflate >=1.8,<1.9.0a0  # [not (s390x or aarch64)]
+    - libdeflate >=1.7,<1.8.0a0  # [s390x or aarch64]
 
 test:
   downstreams:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   host:
     - jpeg 9e
     - libwebp-base  # [linux or osx]
-    - xz 5.2.4
+    - xz 5.2.*
     - zlib 1.2.11
     - zstd 1.5.2
     - lerc 3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - libwebp-base  # [linux or osx]
     - xz 5.2.4
     - zlib 1.2.11
-    - zstd 1.5.2,
+    - zstd 1.5.2
     - lerc 3.0
     - libdeflate 1.7  # [not arm64]
     - libdeflate 1.8  # [arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,12 @@ source:
       - patches/set_configure_script_version.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     # Does a very good job of maintaining compatibility.
     #    https://abi-laboratory.pro/tracker/timeline/libtiff/
     - {{ pin_subpackage('libtiff', max_pin='x') }}
-  ignore_run_exports:
-    - jpeg        # [win]
-    - xz          # [win]
-    - zlib        # [win]
-    - zstd        # [win]
-    - lerc        # [win]
-    - libdeflate  # [win]
   missing_dso_whitelist:
     # Only used by libtiff,bin/tiffgt (a viewer), which is ok.
     - /opt/X11/lib/libGL.1.dylib
@@ -40,21 +33,22 @@ requirements:
     - ninja         # [win]
     - patch         # [osx]
   host:
-    - jpeg
+    - jpeg 9e
     - libwebp-base  # [linux or osx]
-    - xz
-    - zlib
-    - zstd
-    - lerc
-    - libdeflate
+    - xz 5.2.4
+    - zlib 1.2.11
+    - zstd 1.5.2,
+    - lerc 3.0
+    - libdeflate 1.7  # [not arm64]
+    - libdeflate 1.8  # [arm64]
   run:
-    - jpeg
+    - jpeg >=9e,<10a
     - libwebp-base  # [linux or osx]
-    - xz
-    - zlib
-    - zstd
-    - lerc
-    - libdeflate
+    - xz >=5.2.4,<6.0a0
+    - zlib >=1.2.11,<1.3.0a0
+    - zstd >=1.5.2,<1.6.0a0
+    - lerc >=3.0,<4.0a0
+    - libdeflate >=1.8,<1.9.0a0
 
 test:
   downstreams:


### PR DESCRIPTION
* remove ignore-run-exports
* bump build number
* add pinnings to host and version ranges to run-section
* added abs.yaml for turning off overdependency errors
* adjusted .gitattributes for using LF-text for patch and diff files

In general it is not 100% clear what we should do about libwebp-base package ... As we pin libwebp in CBC, but don't do this for its base package, I am in doubt if that is correct in general .... but well not too much things at once