### PR TITLE
Update to 4.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.0" %}
+{% set version = "4.5.1" %}
 
 package:
   name: libtiff
@@ -6,14 +6,13 @@ package:
 
 source:
   - url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
-    sha256: c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464
+    sha256: d7f38b6788e4a8f5da7940c5ac9424f494d8a79eba53d555f4a507167dca5e2b
     folder: .
     patches:                                        # [osx]
       - patches/set_configure_script_version.patch  # [osx]
 
 build:
-  number: 2
-  skip: true  # [win and vc<14]
+  number: 0
   run_exports:
     # Does a very good job of maintaining compatibility.
     #    https://abi-laboratory.pro/tracker/timeline/libtiff/
@@ -34,7 +33,7 @@ requirements:
     - patch         # [osx]
   host:
     - jpeg 9e
-    - libwebp-base  # [linux or osx]
+    - libwebp-base 1.2.4 # [linux or osx]
     - xz 5.2.*
     - zlib 1.2.13  # should be actually 1.2.11, but pinning hell
     - zstd 1.5.2
@@ -42,7 +41,7 @@ requirements:
     - libdeflate 1.17
   run:
     - jpeg >=9e,<10a
-    - libwebp-base  # [linux or osx]
+    - libwebp-base >=1.2.4,<2.0a0 # [linux or osx]
     - xz >=5.2.4,<6.0a0
     - zlib >=1.2.13,<1.3.0a0
     - zstd >=1.5.2,<1.6.0a0

--- a/recipe/patches/set_configure_script_version.patch
+++ b/recipe/patches/set_configure_script_version.patch
@@ -24,6 +24,9 @@ When libtiff alters the LIBTIFF_CURRENT or LIBTIFF_AGE values, this patch will
 need to be updated (it will fail to apply when that occurs). Hopefully, changes
 can be made upstream to better address this before that happens.
 
+Update to 4.5.1 from 4.5.0 : no changes to the API, as a result, only 
+LIBTIFF_REVISION was incremented. Therefore LIBTIFF_REVISION is incremented to 1.
+
 --- configure	2023-01-10 14:40:57.000000000 -0700
 +++ configure 	2023-01-10 14:15:28.000000000 -0700
 @@ -3721,9 +3721,9 @@
@@ -32,7 +35,7 @@ can be made upstream to better address this before that happens.
  
 -LIBTIFF_CURRENT=6
 +LIBTIFF_CURRENT=14
- LIBTIFF_REVISION=0
+ LIBTIFF_REVISION=1
 -LIBTIFF_AGE=0
 +LIBTIFF_AGE=8 
  LIBTIFF_VERSION_INFO=$LIBTIFF_CURRENT:$LIBTIFF_REVISION:$LIBTIFF_AGE


### PR DESCRIPTION
Changes:
- Update to 4.5.1
- pin libwebp-base explicitely
- update patch with comment

https://gitlab.com/libtiff/libtiff/-/tree/v4.5.1?ref_type=tags

