### PR TITLE
libtiff 4.5.1: Rebuild with lerc 4 and libdeflate 1.22

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,5 +3,5 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
   - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,3 +16,7 @@ if errorlevel 1 exit /b 1
 
 copy "%LIBRARY_PREFIX%"\bin\tiff.dll "%LIBRARY_PREFIX%"\bin\libtiff.dll
 if errorlevel 1 exit /b 1
+
+:: libtiff.lib is missing on win
+copy "%LIBRARY_PREFIX%"\lib\tiff.lib "%LIBRARY_PREFIX%"\lib\libtiff.lib
+if errorlevel 1 exit /b 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,11 @@ requirements:
   run:
     - jpeg >=9e,<10a
     - libwebp-base >=1.2.4,<2.0a0 # [linux or osx]
-    - xz >=5.2.4,<6.0a0
+    - xz
     - zlib >=1.2.13,<1.3.0a0
     - zstd >=1.5.2,<1.6.0a0
-    - lerc >=4.0.0,<5.0.0a0
-    - libdeflate >=1.22,<1.23a0
+    - lerc
+    - libdeflate
 
 test:
   downstreams:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - patches/set_configure_script_version.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # Does a very good job of maintaining compatibility.
     #    https://abi-laboratory.pro/tracker/timeline/libtiff/
@@ -36,17 +36,17 @@ requirements:
     - libwebp-base 1.2.4 # [linux or osx]
     - xz 5.2.*
     - zlib 1.2.13  # should be actually 1.2.11, but pinning hell
-    - zstd 1.5.2
-    - lerc 3.0
-    - libdeflate 1.17
+    - zstd {{ zstd }}
+    - lerc 4
+    - libdeflate 1.22
   run:
     - jpeg >=9e,<10a
     - libwebp-base >=1.2.4,<2.0a0 # [linux or osx]
     - xz >=5.2.4,<6.0a0
     - zlib >=1.2.13,<1.3.0a0
     - zstd >=1.5.2,<1.6.0a0
-    - lerc >=3.0,<4.0a0
-    - libdeflate >=1.17,<1.18.0a0
+    - lerc >=4.0.0,<5.0.0a0
+    - libdeflate >=1.22,<1.23a0
 
 test:
   downstreams:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6444](https://anaconda.atlassian.net/browse/PKG-6444) 
- [Upstream repository](https://gitlab.com/libtiff/libtiff/-/tree/v4.5.1?ref_type=tags)

### Explanation of changes:

- Pin host deps:
```
    - lerc 4
    - libdeflate 1.22
```
- Remove runtime pins for xz, lerc, and libdeflate, see an explanation below.

### Notes:

- imagecodecs 2024.9.22 requires lerc 4 and libdeflate 1.22  https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/17

[PKG-6444]: https://anaconda.atlassian.net/browse/PKG-6444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ