### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,7 @@ cp $BUILD_PREFIX/share/libtool/build-aux/config.* ./config
             --host=$HOST \
             --build=$BUILD \
             --disable-static \
+            --disable-docs \
             --with-zlib-include-dir="${PREFIX}/include" \
             --with-zlib-lib-dir="${PREFIX}/lib" \
             --with-jpeg-include-dir="${PREFIX}/include" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - patches/use_unix_io.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # Does a very good job of maintaining compatibility.
     #    https://abi-laboratory.pro/tracker/timeline/libtiff/
@@ -27,9 +27,8 @@ requirements:
     - libtool       # [unix]
     - make          # [not win]
     - ninja-base    # [win]
-    - m2-patch      # [win]
   host:
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libwebp-base {{ libwebp }}
     - xz {{ xz }}
     - zlib {{ zlib }}
@@ -39,7 +38,7 @@ requirements:
     - lerc 4
     - libdeflate 1.22
   run:
-    - jpeg
+    - libjpeg-turbo
     - libwebp-base
     - xz
     - zlib


### PR DESCRIPTION
libtiff 4.7.1

**Destination channel:**  defaults

### Links

- [PKG-13222](https://anaconda.atlassian.net/browse/PKG-13222) 
- [Upstream repository](https://gitlab.com/libtiff/libtiff)

### Explanation of changes:
- Rebuild against libjpeg-turbo


[PKG-13222]: https://anaconda.atlassian.net/browse/PKG-13222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ